### PR TITLE
fix: wouldn't build

### DIFF
--- a/mosquitto.c
+++ b/mosquitto.c
@@ -888,8 +888,8 @@ static int strerror_r(int errnum, char *buf, size_t buf_len)
 
 PHP_MOSQUITTO_API char *php_mosquitto_strerror_wrapper(int err)
 {
-	char *ret, *buf = ecalloc(256, sizeof(char));
-	ret = strerror_r(err, buf, 256);
+	char *buf = ecalloc(256, sizeof(char));
+	int ret = strerror_r(err, buf, 256);
 	if (!buf[0]) {
 		efree(buf);
 		return NULL;


### PR DESCRIPTION
The build could fail on some compilers due to this warning:

`mosquitto.c:892:13: error: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]`